### PR TITLE
Demonstation of JdbcTemplate class:

### DIFF
--- a/src/main/java/com/oreilly/persistence/dao/JdbcOfficerDAO.java
+++ b/src/main/java/com/oreilly/persistence/dao/JdbcOfficerDAO.java
@@ -1,0 +1,98 @@
+package com.oreilly.persistence.dao;
+
+import com.oreilly.persistence.entities.Officer;
+import com.oreilly.persistence.entities.Rank;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class JdbcOfficerDAO implements OfficerDAO {
+
+   private final JdbcTemplate jdbcTemplate;
+   private final SimpleJdbcInsert insertOfficer;
+
+   @Autowired
+   public JdbcOfficerDAO(JdbcTemplate jdbcTemplate) {
+
+      this.jdbcTemplate = jdbcTemplate;
+      this.insertOfficer = new SimpleJdbcInsert(jdbcTemplate).withTableName("officers").usingGeneratedKeyColumns("id");
+   }
+
+   @Override
+   public Officer save(Officer officer) {
+
+      Map<String, Object> parameters = new HashMap<>();
+      parameters.put("rank", officer.getRank());
+      parameters.put("first_name", officer.getFirstName());
+      parameters.put("last_name", officer.getLastName());
+      Integer newId = (Integer) insertOfficer.executeAndReturnKey(parameters);
+      officer.setId(newId);
+      return officer;
+   }
+
+   @Override
+   public Optional<Officer> findById(Integer id) {
+
+      if(!existsById(id))  return Optional.empty();
+
+      return Optional.of(
+            jdbcTemplate.queryForObject(
+                  "select * from officers where id = ?",
+                  new RowMapper<Officer>() {
+                     @Override
+                     public Officer mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+                        return new Officer(
+                              rs.getInt("id"),
+                              Rank.valueOf(rs.getString("rank")),
+                              rs.getString("first_name"),
+                              rs.getString("last_name")
+                        );
+                     }
+                  },
+                  id)
+      );
+   }
+
+   @Override
+   public List<Officer> findAll() {
+
+      return jdbcTemplate.query(
+            "select * from officers",
+            (rs, rowNum) -> new Officer(
+                  rs.getInt("id"),
+                  Rank.valueOf(rs.getString("rank")),
+                  rs.getString("first_name"),
+                  rs.getString("last_name")
+            )
+      );
+   }
+
+   @Override
+   public void delete(Officer officer) {
+
+      jdbcTemplate.update("delete from officers where id = ?", officer.getId());
+   }
+
+   @Override
+   public long count() {
+
+      return jdbcTemplate.queryForObject("select count(1) from officers", Long.class);
+   }
+
+   @Override
+   public boolean existsById(Integer id) {
+
+      return jdbcTemplate.queryForObject("select EXISTS(select 1 from officers where id = ?)", Boolean.class, id);
+   }
+}

--- a/src/test/java/com/oreilly/persistence/dao/JdbcOfficerDAOTest.java
+++ b/src/test/java/com/oreilly/persistence/dao/JdbcOfficerDAOTest.java
@@ -1,0 +1,82 @@
+package com.oreilly.persistence.dao;
+
+import com.oreilly.persistence.entities.Officer;
+import com.oreilly.persistence.entities.Rank;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+@SpringBootTest
+@Transactional
+public class JdbcOfficerDAOTest {
+
+   @Autowired
+   private JdbcOfficerDAO dao;
+
+   @Test
+   void save() {
+
+      Officer officer = new Officer(Rank.ENSIGN, "Wesely", "Crusher");
+      officer = dao.save(officer);
+      assertNotNull(officer.getId());
+   }
+
+   @Test
+   void findByIdThatExists() {
+
+      Optional<Officer> officer = dao.findById(1);
+      assertTrue(officer.isPresent());
+      assertEquals(1, officer.get().getId().intValue());
+   }
+
+   @Test
+   void findByIdThatDoesNotExist() {
+
+      Optional<Officer> officer = dao.findById(999);
+      assertFalse(officer.isPresent());
+   }
+
+   @Test
+   void count() {
+
+      assertEquals(5, dao.count());
+   }
+
+   @Test
+   void findAll() {
+
+      List<String> dbNames = dao.findAll().stream()
+            .map(Officer::getLastName)
+            .collect(Collectors.toList());
+      assertThat(dbNames, containsInAnyOrder("Archer", "Janeway", "Kirk", "Picard", "Sisko"));
+   }
+
+   @Test
+   void delete() {
+
+      IntStream.rangeClosed(1, 5)
+            .forEach(id -> {
+               Optional<Officer> officer = dao.findById(id);
+               assertTrue(officer.isPresent());
+               dao.delete(officer.get());
+            });
+      assertEquals(0, dao.count());
+   }
+
+   @Test
+   void existsById() {
+
+      IntStream.rangeClosed(1, 5)
+            .forEach(id -> assertTrue(dao.existsById(id)));
+   }
+}


### PR DESCRIPTION
- Used when spring needs to connect to DB and we know what SQL query that needs to be executed.
- All exceptions in Spring are unchecked exceptions. JdbcTemplate catches few checked SQL exceptions and rethrows them as instance of a hierarchy of unchecked exceptions - Consistent Exception Hierarchy.
- JdbcTemplate has method called queryOfObject - executes a sql query whose results should be a single value such as Integer, Long, Boolean etc. Supports binding a variable to plug into the sql string.
- JdbcTemplate class's queryForObject also has one overloaded version where in it takes a parameter of type RowMapper<T> that converts the result of SQL query into a desired target type. This interfact has single abstract method called mapRow() that takes ResultSet & rowNum as arguments. Hence its implementation cab be done as lambda on the fly.
- JdbcTemplate also has a method called query() that executes a SQL query and converts into a List of desired types. Takes sql query string and row mapper interfact type as argument.
- JdbcTemplate also has a method called update() to perform insert, update and delete operation on the table. When used to insert, it will not return primary key of row inserted but returns number of rows affected which will usually be 1 per insert. In such case we use SimpleJdbcInsert that has a nice method to return value of any auto-generated column.
- Added a JdbcTemplate based implementation of OffierDAO.
 - Add @Repository to JdbcOfficerDAO: makes it Spring managed component and provides exception translation from SQL exception to one of exceptions under consistent exception hierarchy.
- Added a test class to test the JdbcTemplate based implemention of Officer DAO. Used @Transactional annotation to test class which will help run every test run in seperate transaction and since its test class, as part of transaction, the changes done during transaction are rolled back at the end of each test.